### PR TITLE
Mark explanations as costly when they contain congruence

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -306,6 +306,7 @@ impl EGraph<EClass> {
         self.inner.clear();
     }
 
+    /// Returns whether the explanation used congruence
     pub fn explain_equivalence(
         &mut self,
         id1: Id,
@@ -315,8 +316,8 @@ impl EGraph<EClass> {
         base_unions: usize,
         last_unions: usize,
         eq_ids: &mut EqIds,
-    ) {
-        self.explain
+    ) -> bool {
+        let mut explain = self.explain
             .promote(
                 &self.inner,
                 res,
@@ -324,8 +325,9 @@ impl EGraph<EClass> {
                 base_unions as u32,
                 last_unions as u32,
                 eq_ids,
-            )
-            .explain_equivalence(id1, id2)
+            );
+        explain.explain_equivalence(id1, id2);
+        explain.used_congruence()
     }
 }
 

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -212,6 +212,7 @@ pub(crate) struct ExplainState<'a, X> {
     // decision level than the current one
     last_unions: u32,
     eq_ids: &'a mut EqIds,
+    used_congruence: bool,
 }
 
 impl Explain {
@@ -263,6 +264,7 @@ impl Explain {
             out,
             eq_ids,
             last_unions,
+            used_congruence: false,
         }
     }
 }
@@ -284,6 +286,9 @@ impl<'a, X> DerefMut for ExplainState<'a, X> {
 impl<'x>
     ExplainState<'x, &'x RawEGraph<SymbolLang, EClass, plat_egg::raw::semi_persistent1::UndoLog>>
 {
+    pub(crate) fn used_congruence(&self) -> bool {
+        self.used_congruence
+    }
     // Requires `left` != `right`
     // `result.1` is true when the `old_root` from `result.0` corresponds to left
     fn max_assoc_union_gen<S: IdSet>(
@@ -381,6 +386,7 @@ impl<'x>
                 return;
             }
         }
+        self.used_congruence = true;
         trace!("id{left} = id{right} by fused congruence {flip}");
         let current_node = self.raw.id_to_node(left);
         let next_node = self.raw.id_to_node(right);


### PR DESCRIPTION
This works similarly to dynamic ackermannization