### PR TITLE
Use `second-stack-vec` to avoid unnecessary allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d3b756e34402640015c5fec93cfdb93a4d22740996674392aa7ab8b996e8b4"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +265,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +452,7 @@ dependencies = [
  "platsat",
  "rstest",
  "rustc-hash",
+ "second-stack-vec",
  "smallvec",
  "thiserror-no-std",
  "walkdir",
@@ -602,6 +632,14 @@ name = "saturating"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
+name = "second-stack-vec"
+version = "0.1.0"
+source = "git+https://github.com/dewert99/second-stack-vec#b1168fdf9497897c18705396a0aa6972205f402c"
+dependencies = [
+ "aligned-vec",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,16 @@ edition = "2021"
 
 [dependencies]
 platsat = { git = "https://github.com/dewert99/platsat", branch = "main", features = ["logging"] }
-plat-egg = {git = "https://github.com/dewert99/plat-egg", branch = "main", default-features = false}
-rustc-hash = {version = "1.1.0", default-features = false}
+plat-egg = { git = "https://github.com/dewert99/plat-egg", branch = "main", default-features = false}
+rustc-hash = { version = "1.1.0", default-features = false}
 hashbrown = { version = "0.14.3" , default-features = false}
 log = { version = "0.4.20", default-features = false }
 thiserror-no-std = "2.0.1"
-env_logger = {version = "0.10.0", optional = true}
+env_logger = { version = "0.10.0", optional = true}
 perfect-derive = "0.1.3"
 smallvec = { version = "1.13.1", features = ["union"], default-features = false }
 no-std-compat = { version = "0.4.1" , features = ["alloc"]}
+second-stack-vec = { git = "https://github.com/dewert99/second-stack-vec"}
 
 [features]
 default = ["log/release_max_level_warn"]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use core::fmt::{Debug, Display, Formatter};
 use no_std_compat::prelude::v1::*;
+use second_stack_vec::{Stack, StackVec};
 
 pub(crate) struct DebugIter<'a, I>(pub &'a I);
 
@@ -119,4 +120,12 @@ pub fn powi(mut f: f64, mut exp: u32) -> f64 {
 #[test]
 fn test_powi() {
     debug_assert_eq!(powi(0.1, 5), 0.1f64.powi(5))
+}
+
+pub(crate) fn extend_stack_vec<T, E, F: FnOnce(&mut Stack) -> Result<T, E>>(v: &mut StackVec<T>, mut i: impl Iterator<Item=F>) -> Result<(), E> {
+    i.try_for_each(|f| {
+        let res = f(&mut v.stack())?;
+        v.push(res);
+        Ok(())
+    })
 }


### PR DESCRIPTION
Note: [`second-stack-vec`](https://github.com/dewert99/second-stack-vec), uses `unsafe` that should probably be better audited.